### PR TITLE
Remove agent IDs from code

### DIFF
--- a/app/src/main/python/mistral-client.py
+++ b/app/src/main/python/mistral-client.py
@@ -9,7 +9,7 @@ api_key = os.environ["MISTRAL_API_KEY"]
 client = Mistral(api_key=api_key)
 
 chat_response = client.agents.complete(
-    agent_id="",
+    agent_id="PLACEHOLDER_AGENT_ID",  # Replace with a valid agent_id
     messages=[
         {
             "role": "user",


### PR DESCRIPTION
Remove hardcoded agent ID from `mistral-client.py`.

* Replace the hardcoded `agent_id` with a placeholder `PLACEHOLDER_AGENT_ID` in `mistral-client.py`.
* Add a comment indicating the need to replace the placeholder with a valid `agent_id`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Surfer12/mistral_client/pull/1?shareId=04f792ac-3c35-4944-b4d2-313280d6acf2).